### PR TITLE
skip history update for capture moves

### DIFF
--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -161,11 +161,13 @@ public class MyBot : IChessBot {
                 bestMove = move;
             }
             if (score >= beta) {
-                int change = depth * depth;
-                for (int j = 0; j < moveCount; j++) {
-                    HistoryValue(moves[j]) -= (short)(change + change * HistoryValue(moves[j]) / 4096);
+                if (move.CapturePieceType == 0) {
+                    int change = depth * depth;
+                    for (int j = 0; j < moveCount; j++) {
+                        HistoryValue(moves[j]) -= (short)(change + change * HistoryValue(moves[j]) / 4096);
+                    }
+                    HistoryValue(move) += (short)(change - change * HistoryValue(move) / 4096);
                 }
-                HistoryValue(move) += (short)(change - change * HistoryValue(move) / 4096);
                 break;
             }
             if (score > alpha) {


### PR DESCRIPTION
tested prior to `king-mg` but should be orthogonal
```
ELO   | 31.71 +- 12.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 1648 W: 510 L: 360 D: 778
```