### PR TITLE
Lmr

### DIFF
--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -149,7 +149,11 @@ public class MyBot : IChessBot {
             } else if (moveCount == 0) {
                 score = -Negamax(-beta, -alpha, depth - 1, ply + 1, ref outMove);
             } else {
-                score = -Negamax(-alpha - 1, -alpha, depth - 1, ply + 1, ref outMove);
+                int reduction = move.CapturePieceType != 0 ? 0 : (moveCount * 3 + depth * 4) / 40;
+                score = -Negamax(-alpha - 1, -alpha, depth - reduction - 1, ply + 1, ref outMove);
+                if (score > alpha && reduction != 0) {
+                    score = -Negamax(-alpha - 1, -alpha, depth - 1, ply + 1, ref outMove);
+                }
                 if (score > alpha && score < beta) {
                     score = -Negamax(-beta, -alpha, depth - 1, ply + 1, ref outMove);
                 }


### PR DESCRIPTION
late move reductions (+nonpv fix)
```
ELO   | 74.58 +- 19.01 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 648 W: 229 L: 92 D: 327
```
test is vs nonpv fix but that's neutral so w/e