### PR TITLE
Phased eval flipped

### DIFF
--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -112,7 +112,7 @@ public class MyBot : IChessBot {
                 bool reverse = pieceIndex >= 6;
                 foreach (Piece piece in pieceList) {
                     Square square = piece.Square;
-                    int x = reverse ? square.File : 7 - square.File,
+                    int x = square.File,
                     y = reverse ? square.Rank : 7 - square.Rank,
                     offset = pieceType * 5;
                     staticEval += (constants[offset++]


### PR DESCRIPTION
Uses phased Eval and flips PSTs instead of rotating


Phased Eval
```
ELO   | 8.76 +- 5.88 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 7376 W: 2125 L: 1939 D: 3312
```

Flipped PSTs
```
ELO   | 23.53 +- 11.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 1952 W: 622 L: 490 D: 840
```
