### PR TITLE
don't set move at upper bound node

### DIFF
--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -193,7 +193,8 @@ public class MyBot : IChessBot {
         tt.depth = (byte)Math.Max(depth, 0);
         tt.hash = board.ZobristKey;
         tt.score = (short)bestScore;
-        tt.moveRaw = bestMove.RawValue;
+        if (!tt_good || tt.bound != 3 /* BOUND_UPPER */)
+            tt.moveRaw = bestMove.RawValue;
 
         outMove = bestMove;
         return bestScore;


### PR DESCRIPTION
bench: 2463962
tokens: 986
```
ELO   | 15.66 +- 8.23 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 3464 W: 954 L: 798 D: 1712
```