### PR TITLE
Edge term, own pawns file, eval shrink

### DIFF
--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -95,8 +95,7 @@ public class MyBot : IChessBot {
                 return result;
         }
 
-        int bestScore = -999999;
-        bool raisedAlpha = false;
+        int bestScore = -999999, oldAlpha = alpha;
 
         // static eval for qsearch
         if (depth <= 0) {
@@ -140,8 +139,7 @@ public class MyBot : IChessBot {
             if (staticEval >= beta)
                 return staticEval;
 
-            if (raisedAlpha = staticEval > alpha)
-                alpha = staticEval;
+            alpha = Max(alpha, staticEval);
             bestScore = staticEval;
         }
 
@@ -195,15 +193,12 @@ public class MyBot : IChessBot {
                 }
                 break;
             }
-            if (score > alpha) {
-                raisedAlpha = true;
-                alpha = score;
-            }
+            alpha = Max(alpha, score);
             moveCount++;
         }
 
         tt.bound = (short)(bestScore >= beta ? 2 /* BOUND_LOWER */
-            : raisedAlpha ? 1 /* BOUND_EXACT */
+            : alpha > oldAlpha ? 1 /* BOUND_EXACT */
             : 3 /* BOUND_UPPER */);
         tt.depth = (short)Max(depth, 0);
         tt.hash = board.ZobristKey;


### PR DESCRIPTION
own pawns on file (including eval shrink):
```
ELO   | 11.79 +- 7.51 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 6016 W: 2302 L: 2098 D: 1616
```
edge term:
```
ELO   | 10.65 +- 7.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 6624 W: 2433 L: 2230 D: 1961
```
+ very simple shrink to get under 1030