### PR TITLE
adaptive nmp

### DIFF
--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -120,7 +120,7 @@ public class MyBot : IChessBot {
 
         // Null Move Pruning (NMP)
         if (nonPv && depth >= 1 && board.TrySkipTurn()) {
-            score = -Negamax(-beta, -alpha, depth - 3, nextPly);
+            score = -Negamax(-beta, -alpha, depth * 2 / 3 - 2, nextPly);
             board.UndoSkipTurn();
             if (score >= beta)
                 return score;


### PR DESCRIPTION
+4 tokens
```
ELO   | 8.17 +- 5.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 8760 W: 2911 L: 2705 D: 3144
```
curious about LTC performance (should be even better) so running 60.0+0.0 (tournament TC)