### PR TITLE
Lower history range to [-512, 512]

### DIFF
--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -200,8 +200,8 @@ public class MyBot : IChessBot {
                     tmp = depth * depth;
                     foreach (Move malusMove in moves.AsSpan(0, moveCount))
                         if (!malusMove.IsCapture)
-                            HistoryValue(malusMove) -= (short)(tmp + tmp * HistoryValue(malusMove) / 4096);
-                    HistoryValue(move) += (short)(tmp - tmp * HistoryValue(move) / 4096);
+                            HistoryValue(malusMove) -= (short)(tmp + tmp * HistoryValue(malusMove) / 512);
+                    HistoryValue(move) += (short)(tmp - tmp * HistoryValue(move) / 512);
                     // end tmp use
                 }
                 break;


### PR DESCRIPTION
bench: 1478474
tokens: 1010

Initially made to make history pruning more viable:

Simplification:
```
ELO   | 29.02 +- 13.06 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 1632 W: 555 L: 419 D: 658
```

Gainer:
```
ELO   | 39.49 +- 14.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 1352 W: 477 L: 324 D: 551
```