### PR TITLE
Futility pruning

### DIFF
--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -171,7 +171,7 @@ public class MyBot : IChessBot {
         Move bestMove = nullMove;
         foreach (Move move in moves) {
             //LMP
-            if (nonPv && depth <= 4 && !move.IsCapture && (quietsToCheck-- == 0 || (scores[moveCount] > 256 || eval + 800 < alpha) && moveCount != 0))
+            if (nonPv && depth <= 4 && !move.IsCapture && (quietsToCheck-- == 0 || (scores[moveCount] > 256 || eval + 600 < alpha) && moveCount != 0))
                 break;
 
             board.MakeMove(move);


### PR DESCRIPTION
Futility pruning with static margin
```
ELO   | 16.30 +- 8.68 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 3520 W: 1089 L: 924 D: 1507
```