### PR TITLE
Depth dependent margin for futility pruning

### DIFF
--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -171,7 +171,7 @@ public class MyBot : IChessBot {
         Move bestMove = nullMove;
         foreach (Move move in moves) {
             //LMP
-            if (nonPv && depth <= 4 && !move.IsCapture && (quietsToCheck-- == 0 || (scores[moveCount] > 256 || eval + 600 < alpha) && moveCount != 0))
+            if (nonPv && depth <= 4 && !move.IsCapture && (quietsToCheck-- == 0 || (scores[moveCount] > 256 || eval + 300 * depth < alpha) && moveCount != 0))
                 break;
 
             board.MakeMove(move);


### PR DESCRIPTION
bench: 7188085
tokens: 1022

Futility margin proportional to depth

```
ELO   | 11.91 +- 7.19 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 5136 W: 1560 L: 1384 D: 2192
```