### PR TITLE
Rollup 2

### DIFF
--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -183,19 +183,17 @@ public class MyBot : IChessBot {
 
             board.MakeMove(move);
             int nextDepth = board.IsInCheck() ? depth : depth - 1;
-            if (moveCount == 0)
-                score = -Negamax(-beta, -alpha, nextDepth, nextPly);
-            else {
+            if (moveCount != 0) {
                 // use tmp as reduction
                 tmp = move.IsCapture || nextDepth >= depth ? 0
                     : (moveCount * 76 + depth * 103) / 1000 + Min(moveCount / 7, 1);
                 score = -Negamax(~alpha, -alpha, nextDepth - tmp, nextPly);
                 if (score > alpha && tmp != 0)
                     score = -Negamax(~alpha, -alpha, nextDepth, nextPly);
-                if (score > alpha && score < beta)
-                    score = -Negamax(-beta, -alpha, nextDepth, nextPly);
                 // end tmp use
             }
+            if (moveCount == 0 || score > alpha && score < beta)
+                score = -Negamax(-beta, -alpha, nextDepth, nextPly);
 
             board.UndoMove(move);
 
@@ -252,6 +250,6 @@ public class MyBot : IChessBot {
     ref int HistoryValue(Move move) => ref history[
         board.IsWhiteToMove ? 1 : 0,
         (int)move.MovePieceType,
-        (int)move.TargetSquare.Index
+        move.TargetSquare.Index
     ];
 }


### PR DESCRIPTION
Combines 3 small gainers plus size reduction

`delta-tweak`:
```
ELO   | 3.09 +- 2.35 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 48704 W: 14324 L: 13891 D: 20489
```
`hist-prune-low-alpha`:
```
ELO   | 4.35 +- 3.48 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 22144 W: 6561 L: 6284 D: 9299
```
`nmp-condition-3`:
```
ELO   | 5.78 +- 4.44 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 13656 W: 4093 L: 3866 D: 5697
```

Rollup:
```
ELO   | 10.06 +- 6.52 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 6320 W: 1926 L: 1743 D: 2651
```