### PR TITLE
Nmp eval margin 2

### DIFF
--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -154,7 +154,7 @@ public class MyBot : IChessBot {
             alpha = Max(alpha, bestScore = eval);
         else if (nonPv && eval >= beta && board.TrySkipTurn()) {
             // Null Move Pruning (NMP)
-            bestScore = depth <= 3 ? eval - 44 * depth : -Negamax(-beta, -alpha, depth * 639 / 1000 - 1, nextPly);
+            bestScore = depth <= 3 ? eval - 44 * depth : -Negamax(-beta, -alpha, (depth * 96 + beta - eval) / 150 - 1, nextPly);
             board.UndoSkipTurn();
         }
         if (bestScore >= beta)


### PR DESCRIPTION
+5 tokens
```
ELO   | 8.53 +- 5.83 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 7824 W: 2345 L: 2153 D: 3326
```
time to spsa *again*