### PR TITLE
add history reductions

### DIFF
--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -185,8 +185,11 @@ public class MyBot : IChessBot {
             int nextDepth = board.IsInCheck() ? depth : depth - 1;
             if (moveCount != 0) {
                 // use tmp as reduction
-                tmp = move.IsCapture || nextDepth >= depth ? 0
-                    : (moveCount * 76 + depth * 103) / 1000 + Min(moveCount / 7, 1);
+                tmp = Max(
+                    move.IsCapture || nextDepth >= depth ? 0
+                    : (moveCount * 76 + depth * 103) / 1000 + Min(moveCount / 7, 1) + scores[moveCount] / 256,
+                    0
+                );
                 score = -Negamax(~alpha, -alpha, nextDepth - tmp, nextPly);
                 if (score > alpha && tmp != 0)
                     score = -Negamax(~alpha, -alpha, nextDepth, nextPly);


### PR DESCRIPTION
```
ELO   | 6.89 +- 5.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 10240 W: 3012 L: 2809 D: 4419
```
bench: 5399924
tokens: 1022