### PR TITLE
virtual pawn type

### DIFF
--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -126,6 +126,8 @@ public class MyBot : IChessBot {
                     Square square = new(ClearAndGetIndexOfLSB(ref pieces));
                     Piece piece = board.GetPiece(square);
                     pieceType = (int)piece.PieceType;
+                    // virtual pawn type
+                    // consider pawns on the opposite half of the king as distinct piece types (piece 0)
                     if (
                         square.File >= 4 != board.GetKingSquare(pieceIsWhite = piece.IsWhite).File >= 4
                             && pieceType == 1


### PR DESCRIPTION
 treat pawns on the opposite half of the king as distinct piece types (piece 0)
```
ELO   | 21.36 +- 10.35 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 2720 W: 936 L: 769 D: 1015
```
bench: 5541502
tokens: 1023