### PR TITLE
Own pawn ahead 2

### DIFF
--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -192,9 +192,8 @@ public class MyBot : IChessBot {
             board.MakeMove(move);
             int
                 nextDepth = board.IsInCheck() ? depth : depth - 1,
-                reduction = Max(
-                    nextDepth >= depth ? 0
-                    : (moveCount * 120 + depth * 103) / 1000 + scores[moveCount] / 256,
+                reduction = (depth - nextDepth) * Max(
+                    (moveCount * 120 + depth * 103) / 1000 + scores[moveCount] / 256,
                     0
                 );
             while (


### PR DESCRIPTION
Initial implementation:
```
ELO   | 8.37 +- 5.74 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 8176 W: 2478 L: 2281 D: 3417
```
Bugfix + shrink to fit:
```
ELO   | -0.59 +- 2.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 34520 W: 9781 L: 9840 D: 14899
```