### PR TITLE
Tt shrink plus fix

### DIFF
--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -56,8 +56,8 @@ public class MyBot : IChessBot {
         do
             //If score is of this value search has been aborted, DO NOT use result
             try {
-                if (Abs(lastScore - Negamax(lastScore - 20, lastScore + 20, searchingDepth)) >= 20)
-                    Negamax(-32000, 32000, searchingDepth);
+                if (Abs(lastScore - Negamax(lastScore - 20, lastScore + 20, searchingDepth, false)) >= 20)
+                    Negamax(-32000, 32000, searchingDepth, false);
                 rootBestMove = searchBestMove;
                 //Use for debugging, commented out because it saves a LOT of tokens!!
                 //Console.WriteLine("info depth " + depth + " score cp " + score);
@@ -73,7 +73,7 @@ public class MyBot : IChessBot {
         return rootBestMove;
     }
 
-    public int Negamax(int alpha, int beta, int depth) {
+    public int Negamax(int alpha, int beta, int depth, bool notRoot = true) {
         //abort search
         if (timer.MillisecondsElapsedThisTurn >= maxSearchTime && searchingDepth > 1)
             throw null;
@@ -84,7 +84,7 @@ public class MyBot : IChessBot {
         // check for game end
         if (board.IsInCheckmate())
             return board.PlyCount - 30000;
-        if (board.IsDraw())
+        if (notRoot && board.IsDraw())
             return 0;
 
         ref var tt = ref transpositionTable[board.ZobristKey & 0x7FFFFF];


### PR DESCRIPTION
should fix repetition draws at root, and also brings tables into required size constraint.
```
ELO   | 3.45 +- 5.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 9064 W: 2577 L: 2487 D: 4000
```