### PR TITLE
Revert "use tteval in qsearch"

### DIFF
--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -152,7 +152,7 @@ public class MyBot : IChessBot {
             return (short)eval * tmp + eval / 0x10000 * (24 - tmp);
             // end tmp use
         }
-        eval = ttHit ? score : Eval(board.AllPiecesBitboard) / 24;
+        eval = ttHit && !inQSearch ? score : Eval(board.AllPiecesBitboard) / 24;
 
         if (inQSearch)
             // stand pat in quiescence search


### PR DESCRIPTION
This reverts commit 6fda20e93056ac041808ba10c5a69457b511f74e due to it affecting mate finding.

bench: 4623970
tokens: 1022

Gained with no increment:
```
ELO   | 9.82 +- 6.42 (95%)
SPRT  | 8.0+0.00s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 6512 W: 1981 L: 1797 D: 2734
```

Passed non-regression with increment:
```
ELO   | 2.67 +- 4.91 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 10552 W: 2942 L: 2861 D: 4749
````