### PR TITLE
game over detection rework stuff

### DIFF
--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -276,7 +276,7 @@ public class MyBot : IChessBot {
             alpha > oldAlpha // don't update best move if upper bound (31 elo, 6 tokens, 5.2 elo/token)
                 ? bestMove.RawValue
                 : ttMoveRaw,
-            bestScore,
+            Clamp(bestScore, -20000, 20000),
             Max(depth, 0),
             bestScore >= beta
                 ? 2147483647 /* BOUND_LOWER */


### PR DESCRIPTION
rollup of game over rework + fix for introduced bug (1 token shrink)
```
ELO   | 12.60 +- 7.81 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 3200 W: 732 L: 616 D: 1852
```
```
ELO   | 1.72 +- 4.37 (95%)
SPRT  | 8.0+0.00s Threads=1 Hash=8MB
LLR   | 3.01 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 13520 W: 3807 L: 3740 D: 5973
```